### PR TITLE
fix!: headEnabled should be `@unhead/vue` by default

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -183,7 +183,7 @@ export async function createMarkdown(options: ResolvedOptions) {
 
       if (!isVue2 && headEnabled && head) {
         scriptLines.push(`const head = ${JSON.stringify(head)}`)
-        const importFrom = headEnabled === 'unhead' ? '@unhead/vue' : '@vueuse/head'
+        const importFrom = headEnabled === 'vueuse' ? '@vueuse/head' : '@unhead/vue'
         scriptLines.unshift(`import { useHead } from "${importFrom}"`)
         scriptLines.push('useHead(head)')
       }


### PR DESCRIPTION
### Description
Should now be docs and types.ts correct.

### Linked Issues
Closes: #31 