### PR TITLE
feat: Added option to convert internal links to router links

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -179,6 +179,13 @@ export interface Options {
   wrapperComponent?: string | undefined | null | ((id: string, code: string) => string | undefined | null)
 
   /**
+   * Component name to wrap internal links with.
+   *
+   * @default undefined
+   */
+  routerLinkComponent?: string | undefined | null | ((id: string, code: string) => string | undefined | null)
+
+  /**
    * Custom tranformations apply before and after the markdown transformation
    */
   transforms?: {

--- a/test/__snapshots__/routerLinks.test.ts.snap
+++ b/test/__snapshots__/routerLinks.test.ts.snap
@@ -1,0 +1,60 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`router link transforms > does not convert to router links if router link option is not provided 1`] = `
+{
+  "code": "<template><div class="markdown-body"><h1>Internal links to Router links!</h1>
+<p><a href="/">test</a>
+<a href="/test/1234">test 1234</a>
+<a href="/blog/this-is-my-test-slug-12345">test slug</a></p>
+</div></template>
+<script setup>
+const frontmatter = {}
+defineExpose({ frontmatter })
+</script>",
+  "map": {
+    "mappings": "",
+  },
+}
+`;
+
+exports[`router link transforms > does not transform non-internal links to router links 1`] = `
+"<template><div class="markdown-body"><h1>Non-internal links</h1>
+<p><a href="https://example.com">test</a>
+<a href="#header1234">test 1234</a>
+<a href="https://example.com/this/is/a/really/long/path">test url with long path</a></p>
+</div></template>
+<script setup>
+const frontmatter = {}
+defineExpose({ frontmatter })
+</script>"
+`;
+
+exports[`router link transforms > does not transform non-internal links to router links 2`] = `
+"<template><div class="markdown-body"><h1>Non-internal links</h1>
+<p><a href="https://example.com">test</a>
+<a href="#header1234">test 1234</a>
+<a href="https://example.com/this/is/a/really/long/path">test url with long path</a></p>
+</div></template>
+<script setup>
+const frontmatter = {}
+defineExpose({ frontmatter })
+</script>"
+`;
+
+exports[`router link transforms > supports custom router link components 1`] = `
+"<template><div class="markdown-body"><h1>Internal links to Router links!</h1>
+<MyCustomRouterLink to="/">test</MyCustomRouterLink><MyCustomRouterLink to="/test/1234">test 1234</MyCustomRouterLink><MyCustomRouterLink to="/blog/this-is-my-test-slug-12345">test slug</MyCustomRouterLink></div></template>
+<script setup>
+const frontmatter = {}
+defineExpose({ frontmatter })
+</script>"
+`;
+
+exports[`router link transforms > transforms internal links to router links 1`] = `
+"<template><div class="markdown-body"><h1>Internal links to Router links!</h1>
+<RouterLink to="/">test</RouterLink><RouterLink to="/test/1234">test 1234</RouterLink><RouterLink to="/blog/this-is-my-test-slug-12345">test slug</RouterLink></div></template>
+<script setup>
+const frontmatter = {}
+defineExpose({ frontmatter })
+</script>"
+`;

--- a/test/routerLinks.test.ts
+++ b/test/routerLinks.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { resolveOptions } from '../src/core/options'
+import { createMarkdown } from '../src/core/markdown'
+
+describe('router link transforms', async () => {
+  const optionsNoLink = resolveOptions({})
+  const optionsWithCustomLink = resolveOptions({
+    routerLinkComponent: 'MyCustomRouterLink',
+  })
+  const options = resolveOptions({
+    routerLinkComponent: 'RouterLink',
+  })
+
+  const markdownToVue = await createMarkdown(options)
+  const mdWithoutRouterLink = await createMarkdown(optionsNoLink)
+  const mdWithCustomLink = await createMarkdown(optionsWithCustomLink)
+
+  it('transforms internal links to router links', () => {
+    const md = `
+# Internal links to Router links!
+
+[test](/)
+[test 1234](/test/1234)
+[test slug](/blog/this-is-my-test-slug-12345)
+    `
+
+    expect(markdownToVue('', md).code).toMatchSnapshot()
+  })
+
+  it('does not transform non-internal links to router links', () => {
+    const md = `
+# Non-internal links
+
+[test](https://example.com)
+[test 1234](#header1234)
+[test url with long path](https://example.com/this/is/a/really/long/path)
+    `
+    expect(markdownToVue('', md).code).toMatchSnapshot()
+    expect(mdWithCustomLink('', md).code).toMatchSnapshot()
+  })
+
+  it ('supports custom router link components', () => {
+    const md = `
+# Internal links to Router links!
+
+[test](/)
+[test 1234](/test/1234)
+[test slug](/blog/this-is-my-test-slug-12345)
+    `
+    expect(mdWithCustomLink('', md).code).toMatchSnapshot()
+  })
+
+  it('does not convert to router links if router link option is not provided', () => {
+    const md = `
+# Internal links to Router links!
+
+[test](/)
+[test 1234](/test/1234)
+[test slug](/blog/this-is-my-test-slug-12345)
+    `
+    expect(mdWithoutRouterLink('', md)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds an option to convert internal links to `RouterLinks`. Supports custom router link components. I've also added a new test suite called `routerLink.test.ts`. It contains a total of 4 tests.

### Linked Issues
fix #37 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
