### PR TITLE
feat: introduce `wrapperDiv` option

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -102,6 +102,7 @@ export function createMarkdown(options: ResolvedOptions) {
     const md = await setupPromise
 
     const {
+      wrapperDiv,
       wrapperClasses,
       wrapperComponent,
       transforms,
@@ -116,18 +117,20 @@ export function createMarkdown(options: ResolvedOptions) {
     let html = await md.renderAsync(raw, env)
     const { excerpt = '', frontmatter: data = null } = env
 
-    const wrapperClassesResolved = toArray(
-      typeof wrapperClasses === 'function'
-        ? wrapperClasses(id, raw)
-        : wrapperClasses,
-    )
-      .filter(Boolean)
-      .join(' ')
+    if (wrapperDiv) {
+      const wrapperClassesResolved = toArray(
+        typeof wrapperClasses === 'function'
+          ? wrapperClasses(id, raw)
+          : wrapperClasses,
+      )
+        .filter(Boolean)
+        .join(' ')
 
-    if (wrapperClassesResolved)
-      html = `<div class="${wrapperClassesResolved}">${html}</div>`
-    else
-      html = `<div>${html}</div>`
+      if (wrapperClassesResolved)
+        html = `<div class="${wrapperClassesResolved}">${html}</div>`
+      else
+        html = `<div>${html}</div>`
+    }
 
     const wrapperComponentName = typeof wrapperComponent === 'function'
       ? wrapperComponent(id, raw)

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -17,6 +17,7 @@ export function resolveOptions(userOptions: Options): ResolvedOptions {
     markdownItOptions: {},
     markdownItUses: [],
     markdownItSetup: () => {},
+    wrapperDiv: true,
     wrapperComponent: null,
     transforms: {},
     vueVersion: userOptions.vueVersion || getVueVersion(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,7 @@ export interface Options {
   wrapperClasses?: string | string[] | undefined | null | ((id: string, code: string) => string | string[] | undefined | null)
 
   /**
-   * Component name to wrap with (will wrap the wrapperDiv if present)
+   * Component name to wrapper with
    *
    * @default undefined
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,13 @@ export interface Options {
   markdownItSetup?: (MarkdownIt: MarkdownItAsync) => void | Promise<void>
 
   /**
+   * Wrap the html in a div
+   *
+   * @default true
+   */
+  wrapperDiv?: boolean
+
+  /**
    * Class names for wrapper div
    *
    * @default 'markdown-body'
@@ -177,7 +184,7 @@ export interface Options {
   wrapperClasses?: string | string[] | undefined | null | ((id: string, code: string) => string | string[] | undefined | null)
 
   /**
-   * Component name to wrapper with
+   * Component name to wrap with (will wrap the wrapperDiv if present)
    *
    * @default undefined
    */
@@ -199,7 +206,7 @@ export interface Options {
   exclude?: FilterPattern
 }
 
-export interface ResolvedOptions extends Required<Options> {}
+export interface ResolvedOptions extends Required<Options> { }
 
 export interface MarkdownEnv extends MarkdownItEnv {
   id: string


### PR DESCRIPTION
This PR adds a boolean option `wrapperDiv` that makes the wrapper div optional in a way that doesn't break the existing API.

I can see the value of the wrapper div in some situations but don't see a reason for it to be _required_.

And when a `wrapperComponent` is specified the extra div feels especially unnecessary and gets in the way.

Making it optional allows for cleaner simpler markup and makes, for example, styling easier.

Apologies - I made the PR before discussing but let me know what you think / if it is mergable (or not)

Also, just to say, thanks for a great plugin!!