### PR TITLE
[chore] Adds vite@^7 to the dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "release": "bumpp && npm publish"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0"
+    "vite": "^2.0.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@mdit-vue/plugin-component": "^2.1.3",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Adds vite@^7 in the peerDependency range to remove warnings when adding `unplugin-vue-markdown` to a project having vite version 7+
```pwsh
 WARN  Issues with peer dependencies found
.
├─┬ unplugin-vue-markdown 28.3.1
│ └── ✕ unmet peer vite@"^2.0.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0": found 7.0.0
```

### Linked Issues
*None*

### Additional context
*None*